### PR TITLE
Add command-line refactor support

### DIFF
--- a/src/CommandLine/CommandLine.csproj
+++ b/src/CommandLine/CommandLine.csproj
@@ -71,6 +71,8 @@
     <ProjectReference Include="..\VisualBasic\VisualBasic.csproj" />
     <ProjectReference Include="..\Workspaces.Core\Workspaces.Core.csproj" />
     <ProjectReference Include="..\Documentation\Documentation.csproj" />
+    <ProjectReference Include="..\Refactorings\Refactorings.csproj" />
+    <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommandLine/CommandResults/RefactorCommandResult.cs
+++ b/src/CommandLine/CommandResults/RefactorCommandResult.cs
@@ -1,0 +1,8 @@
+namespace Roslynator.CommandLine;
+
+internal class RefactorCommandResult : CommandResult
+{
+    public RefactorCommandResult(CommandStatus status) : base(status)
+    {
+    }
+}

--- a/src/CommandLine/Commands/RefactorCommand.cs
+++ b/src/CommandLine/Commands/RefactorCommand.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.Text;
+using Roslynator.CSharp.Refactorings;
+using Roslynator;
+using static Roslynator.Logger;
+
+namespace Roslynator.CommandLine;
+
+internal class RefactorCommand : MSBuildWorkspaceCommand<RefactorCommandResult>
+{
+    public RefactorCommand(
+        RefactorCommandLineOptions options,
+        in ProjectFilter projectFilter,
+        FileSystemFilter fileSystemFilter) : base(projectFilter, fileSystemFilter)
+    {
+        Options = options;
+    }
+
+    public RefactorCommandLineOptions Options { get; }
+
+    public override async Task<RefactorCommandResult> ExecuteAsync(ProjectOrSolution projectOrSolution, CancellationToken cancellationToken = default)
+    {
+        Solution solution = projectOrSolution.AsSolution();
+        string solutionDir = Path.GetDirectoryName(solution.FilePath);
+        string filePath = Options.FilePath;
+        if (!Path.IsPathRooted(filePath))
+            filePath = Path.GetFullPath(Path.Combine(solutionDir, filePath));
+
+        DocumentId documentId = solution.GetDocumentIdsWithFilePath(filePath).FirstOrDefault();
+        if (documentId == null)
+        {
+            WriteLine($"Document '{filePath}' not found.", ConsoleColors.Yellow, Verbosity.Quiet);
+            return new RefactorCommandResult(CommandStatus.Fail);
+        }
+
+        Document document = solution.GetDocument(documentId);
+        if (document == null)
+        {
+            WriteLine($"Unable to get document '{filePath}'.", ConsoleColors.Yellow, Verbosity.Quiet);
+            return new RefactorCommandResult(CommandStatus.Fail);
+        }
+
+        TextSpan span = ParsePosition(await document.GetTextAsync(cancellationToken));
+        var provider = new RoslynatorCodeRefactoringProvider();
+        var actions = new List<CodeAction>();
+        var context = new CodeRefactoringContext(document, span, a => actions.Add(a), cancellationToken);
+        await provider.ComputeRefactoringsAsync(context);
+
+        RefactoringDescriptor descriptor = GetDescriptor(Options.RefactoringId);
+        string eqKey = "Roslynator." + descriptor.Id;
+        CodeAction action = actions.FirstOrDefault(a => string.Equals(a.EquivalenceKey, eqKey, StringComparison.Ordinal));
+        if (action == null)
+        {
+            WriteLine("Refactoring not found at the specified location.", ConsoleColors.Yellow, Verbosity.Quiet);
+            return new RefactorCommandResult(CommandStatus.Fail);
+        }
+
+        WriteLine($"Applying '{action.Title}'", ConsoleColors.Cyan, Verbosity.Normal);
+        ImmutableArray<CodeActionOperation> operations = await action.GetOperationsAsync(cancellationToken);
+        ApplyChangesOperation applyOperation = operations.OfType<ApplyChangesOperation>().First();
+        if (!solution.Workspace.TryApplyChanges(applyOperation.ChangedSolution))
+        {
+            WriteLine("Failed to apply changes to workspace.", ConsoleColors.Yellow, Verbosity.Quiet);
+            return new RefactorCommandResult(CommandStatus.Fail);
+        }
+
+        return new RefactorCommandResult(CommandStatus.Success);
+
+        TextSpan ParsePosition(SourceText text)
+        {
+            string[] parts = Options.Position.Split(':');
+            int line = int.Parse(parts[0]) - 1;
+            int character = int.Parse(parts[1]) - 1;
+            int start = text.Lines[line].Start + character;
+            return new TextSpan(start, 0);
+        }
+
+        static RefactoringDescriptor GetDescriptor(string id)
+        {
+            foreach (FieldInfo field in typeof(RefactoringDescriptors).GetFields(BindingFlags.Public | BindingFlags.Static))
+            {
+                if (field.GetValue(null) is RefactoringDescriptor d && d.Id == id)
+                    return d;
+            }
+            throw new InvalidOperationException($"Refactoring descriptor '{id}' not found.");
+        }
+    }
+}

--- a/src/CommandLine/OptionNames.cs
+++ b/src/CommandLine/OptionNames.cs
@@ -44,4 +44,8 @@ internal static class OptionNames
     public const string Type = "type";
     public const string Visibility = "visibility";
     public const string WrapList = "wrap-list";
+
+    public const string RefactoringId = "refactoring-id";
+    public const string FilePath = "file";
+    public const string Position = "position";
 }

--- a/src/CommandLine/Options/RefactorCommandLineOptions.cs
+++ b/src/CommandLine/Options/RefactorCommandLineOptions.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using CommandLine;
+
+namespace Roslynator.CommandLine;
+
+[Verb("refactor", HelpText = "Applies C# refactoring at specified location in a project or solution.")]
+public class RefactorCommandLineOptions : MSBuildCommandLineOptions
+{
+    [Value(index:0, HelpText="Path to one or more project/solution files.", MetaName="<PROJECT|SOLUTION>")]
+    public IEnumerable<string> Paths { get; set; }
+
+    [Option(longName: OptionNames.RefactoringId, Required = true, HelpText="Identifier of the refactoring to apply (e.g. RR0011).", MetaValue = "<ID>")]
+    public string RefactoringId { get; set; }
+
+    [Option(longName: OptionNames.FilePath, Required = true, HelpText="Path to the document where refactoring should be applied.", MetaValue = "<FILE_PATH>")]
+    public string FilePath { get; set; }
+
+    [Option(longName: OptionNames.Position, Required = true, HelpText="Position defined as 'line:char' (1-based).", MetaValue = "<LINE:CHAR>")]
+    public string Position { get; set; }
+}

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -105,6 +105,7 @@ internal static class Program
                     typeof(MigrateCommandLineOptions),
                     typeof(PhysicalLinesOfCodeCommandLineOptions),
                     typeof(RenameSymbolCommandLineOptions),
+                    typeof(RefactorCommandLineOptions),
                     typeof(SpellcheckCommandLineOptions),
                     typeof(FindSymbolCommandLineOptions),
                 });
@@ -189,6 +190,8 @@ internal static class Program
                             return PhysicalLinesOfCodeAsync(physicalLinesOfCodeCommandLineOptions).Result;
                         case RenameSymbolCommandLineOptions renameSymbolCommandLineOptions:
                             return RenameSymbolAsync(renameSymbolCommandLineOptions).Result;
+                        case RefactorCommandLineOptions refactorCommandLineOptions:
+                            return RefactorAsync(refactorCommandLineOptions).Result;
                         case SpellcheckCommandLineOptions spellcheckCommandLineOptions:
                             return SpellcheckAsync(spellcheckCommandLineOptions).Result;
                         case FindSymbolCommandLineOptions findSymbolCommandLineOptions:
@@ -459,6 +462,24 @@ internal static class Program
             codeContext: -1,
             predicate: predicate,
             getNewName: getNewName);
+
+        CommandStatus status = await command.ExecuteAsync(paths, options.MSBuildPath, options.Properties);
+
+        return GetExitCode(status);
+    }
+
+    private static async Task<int> RefactorAsync(RefactorCommandLineOptions options)
+    {
+        if (!options.TryGetProjectFilter(out ProjectFilter projectFilter))
+            return ExitCodes.Error;
+
+        if (!TryParsePaths(options.Paths, out ImmutableArray<PathInfo> paths))
+            return ExitCodes.Error;
+
+        var command = new RefactorCommand(
+            options: options,
+            projectFilter: projectFilter,
+            fileSystemFilter: CreateFileSystemFilter(options));
 
         CommandStatus status = await command.ExecuteAsync(paths, options.MSBuildPath, options.Properties);
 


### PR DESCRIPTION
## Summary
- add CLI verb `refactor`
- implement `RefactorCommand` to apply a specified refactoring at a file position
- expose new options in `OptionNames`
- hook command into program flow and include project references

## Testing
- `dotnet build src/Roslynator.sln -c Release --no-restore` *(fails: Assets file /workspace/roslynator/src/Tests/TestLibrary/obj/project.assets.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c8e6a56c83279cd1958a02febd8d