### PR TITLE
Add CLI refactor command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Run following command to install Roslynator command line tool:
 ```sh
 dotnet tool install -g roslynator.dotnet.cli
 ```
+You can apply a specific refactoring without an IDE:
+```sh
+roslynator refactor --file MyFile.cs --span 0:0 --refactoring RR0010
+```
 
 See [documentation](https://josefpihrt.github.io/docs/roslynator/cli) for further information.
 

--- a/src/CommandLine/CommandLine.csproj
+++ b/src/CommandLine/CommandLine.csproj
@@ -67,6 +67,7 @@
   <ItemGroup>
     <ProjectReference Include="..\CSharp.Workspaces\CSharp.Workspaces.csproj" />
     <ProjectReference Include="..\CSharp\CSharp.csproj" />
+    <ProjectReference Include="..\Refactorings\Refactorings.csproj" />
     <ProjectReference Include="..\VisualBasic.Workspaces\VisualBasic.Workspaces.csproj" />
     <ProjectReference Include="..\VisualBasic\VisualBasic.csproj" />
     <ProjectReference Include="..\Workspaces.Core\Workspaces.Core.csproj" />

--- a/src/CommandLine/Commands/RefactorCommand.cs
+++ b/src/CommandLine/Commands/RefactorCommand.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using Roslynator.CSharp.Refactorings;
+using static Roslynator.Logger;
+
+namespace Roslynator.CommandLine;
+
+internal class RefactorCommand
+{
+    public RefactorCommand(RefactorCommandLineOptions options)
+    {
+        Options = options;
+    }
+
+    public RefactorCommandLineOptions Options { get; }
+
+    public async Task<CommandStatus> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(Options.File))
+        {
+            WriteLine($"File not found: '{Options.File}'", ConsoleColors.Yellow, Verbosity.Quiet);
+            return CommandStatus.Fail;
+        }
+
+        string text = await File.ReadAllTextAsync(Options.File, cancellationToken);
+        (int start, int length) = ParseSpan(Options.Span, text.Length);
+        var workspace = new AdhocWorkspace();
+        var references = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES").ToString().Split(Path.PathSeparator).Select(f => MetadataReference.CreateFromFile(f));
+        Project project = workspace.CurrentSolution.AddProject("Refactor", "Refactor", LanguageNames.CSharp)
+            .WithMetadataReferences(references)
+            .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        Document document = project.AddDocument(Path.GetFileName(Options.File), SourceText.From(text), filePath: Options.File);
+
+        var provider = new RoslynatorCodeRefactoringProvider();
+        CodeAction action = null;
+        var span = new TextSpan(start, length);
+        var context = new CodeRefactoringContext(document, span, a =>
+        {
+            if (action == null)
+            {
+                if (Options.RefactoringId == null || a.EquivalenceKey == Options.RefactoringId || a.Title.IndexOf(Options.RefactoringId, StringComparison.OrdinalIgnoreCase) >= 0)
+                    action = a;
+            }
+        }, cancellationToken);
+        await provider.ComputeRefactoringsAsync(context);
+
+        if (action == null)
+        {
+            WriteLine("No matching refactoring found.", Verbosity.Minimal);
+            return CommandStatus.NotSuccess;
+        }
+
+        var operations = await action.GetOperationsAsync(cancellationToken);
+        var apply = operations.OfType<ApplyChangesOperation>().FirstOrDefault();
+        if (apply is null)
+            return CommandStatus.NotSuccess;
+
+        Document newDocument = apply.ChangedSolution.GetDocument(document.Id);
+        SourceText newText = await newDocument.GetTextAsync(cancellationToken);
+        await File.WriteAllTextAsync(Options.File, newText.ToString(), cancellationToken);
+        return CommandStatus.Success;
+    }
+
+    private static (int start, int length) ParseSpan(string s, int maxLength)
+    {
+        if (!string.IsNullOrEmpty(s))
+        {
+            var parts = s.Split(':');
+            if (parts.Length == 2 && int.TryParse(parts[0], out int start) && int.TryParse(parts[1], out int length))
+            {
+                start = Math.Max(0, Math.Min(start, maxLength));
+                length = Math.Max(0, Math.Min(length, maxLength - start));
+                return (start, length);
+            }
+        }
+        return (0, 0);
+    }
+}

--- a/src/CommandLine/OptionNames.cs
+++ b/src/CommandLine/OptionNames.cs
@@ -44,4 +44,7 @@ internal static class OptionNames
     public const string Type = "type";
     public const string Visibility = "visibility";
     public const string WrapList = "wrap-list";
+    public const string File = "file";
+    public const string Span = "span";
+    public const string RefactoringId = "refactoring";
 }

--- a/src/CommandLine/Options/RefactorCommandLineOptions.cs
+++ b/src/CommandLine/Options/RefactorCommandLineOptions.cs
@@ -1,0 +1,16 @@
+using CommandLine;
+
+namespace Roslynator.CommandLine;
+
+[Verb("refactor", HelpText = "Apply a code refactoring to a single file.")]
+public class RefactorCommandLineOptions : BaseCommandLineOptions
+{
+    [Option(longName: OptionNames.File, Required = true, HelpText = "Path to C# file.")]
+    public string File { get; set; }
+
+    [Option(longName: OptionNames.Span, HelpText = "Text span in the form start:length.", MetaValue = "<SPAN>")]
+    public string Span { get; set; }
+
+    [Option(longName: OptionNames.RefactoringId, HelpText = "Refactoring id or title substring.")]
+    public string RefactoringId { get; set; }
+}

--- a/src/CommandLine/Program.cs
+++ b/src/CommandLine/Program.cs
@@ -107,6 +107,7 @@ internal static class Program
                     typeof(RenameSymbolCommandLineOptions),
                     typeof(SpellcheckCommandLineOptions),
                     typeof(FindSymbolCommandLineOptions),
+                    typeof(RefactorCommandLineOptions),
                 });
 
             parserResult.WithNotParsed(e =>
@@ -205,6 +206,8 @@ internal static class Program
                             return Help(helpCommandLineOptions);
                         case MigrateCommandLineOptions migrateCommandLineOptions:
                             return Migrate(migrateCommandLineOptions);
+                        case RefactorCommandLineOptions refactorCommandLineOptions:
+                            return RefactorAsync(refactorCommandLineOptions).Result;
                         default:
                             throw new InvalidOperationException();
                     }
@@ -822,6 +825,15 @@ internal static class Program
             options.DryRun);
 
         CommandStatus status = command.Execute();
+
+        return GetExitCode(status);
+    }
+
+    private static async Task<int> RefactorAsync(RefactorCommandLineOptions options)
+    {
+        var command = new RefactorCommand(options);
+
+        CommandStatus status = await command.ExecuteAsync();
 
         return GetExitCode(status);
     }


### PR DESCRIPTION
## Summary
- add new `refactor` command for Roslynator CLI
- support options `--file`, `--span`, and `--refactoring`
- wire new command into parser and command dispatch
- document CLI refactoring command usage in README

## Testing
- `dotnet build src/CommandLine.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6846cce14190832797b2486ab885407b